### PR TITLE
#19-Showing-available-days

### DIFF
--- a/web/modules/custom/movie/templates/movie-theme-hook.html.twig
+++ b/web/modules/custom/movie/templates/movie-theme-hook.html.twig
@@ -7,6 +7,12 @@
     <img src={{ file_url(movie.field_image.entity.uri.value) }} alt="{{ movie.field_image.alt }}" width={{ movie.field_image.width}} height={{ movie.field_image.height}}>
     <h3>{{ movie.label }}</h3>
     <p>{{ movie.field_description.value | raw}}</p>
+    <h4>Available to watch on: </h4>
+    <ul>
+      {% for day in movie.field_available_on %}
+        <li>{{ day.entity.name.value }}</li>
+      {% endfor %}
+    </ul>
   </div>
 {% endfor %}
 


### PR DESCRIPTION
I created new vocabulary with working days as terms and added new fields to Movie content type.
There can be max 5 terms for every movie, because there is 5 days of the week.
I am showing available days for every movie on '/movie' URL with the 'movie-theme-hook.html.twig'